### PR TITLE
Fix UI issues: Remove extra > mark and update calendar icon

### DIFF
--- a/Public/index.html
+++ b/Public/index.html
@@ -140,7 +140,7 @@
                 </div>
             </div>
             </div>
-        </section>>
+        </section>
 
         <!-- Stats Section -->
         <section id="stats" class="stats section light-background">
@@ -173,7 +173,7 @@
 
                     <div class="col-lg-3 col-md-6">
                         <div class="stats-item d-flex align-items-center w-100 h-100">
-                            <i class="bi bi-calendar-date color-green flex-shrink-0"></i>
+                            <i class="bi bi-calendar3 color-green flex-shrink-0"></i>
                             <div>
                                 <span data-purecounter-start="0" data-purecounter-end="600"
                                     data-purecounter-duration="1" class="purecounter"></span>


### PR DESCRIPTION
- Removed extra '>' character after About section
- Changed calendar icon from bi-calendar-date to bi-calendar3 to show clean calendar without numbers
- Fixes inconsistency where icon showed '19' but text displayed '600' for weekends counter